### PR TITLE
Changed storage location to follow the XDG specification

### DIFF
--- a/rfc/rfc.py
+++ b/rfc/rfc.py
@@ -18,7 +18,7 @@ __version__ = "0.8"
 
 
 class Config(object):
-    LOCAL_STORAGE_PATH = "~/.rfc"
+    LOCAL_STORAGE_PATH = os.getenv('XDG_DATA_HOME', "~/.local/share/rfc")
     INDEX_NAME = "rfc-index.txt"
 
 
@@ -258,6 +258,9 @@ def main():
     config = parser.parse_args()
 
     pager = config.pager[0] if config.pager else None
+
+    if not os.path.isdir(Config.LOCAL_STORAGE_PATH):
+        os.makedirs(Config.LOCAL_STORAGE_PATH)
 
     app = RFCApp(pager)
     if config.update:


### PR DESCRIPTION
This patch changes the LOCAL_STORAGE_PATH to follow the XDG specification so this tool doesn't litter the homedir with extra hidden directories. 

https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
