### PR TITLE
Use a safer extraction method for untarring the archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,17 @@ rfc_reader will download and/or update all RFC txt documents from [rfc-editor-we
 `rfc -k UDP` outputs the summary of all RFC documents including the word 'UDP'
 
 ## History :
+- 1.0 :
+    - adds XDG compliant storage path ([MartijnBraam](https://github.com/MartijnBraam))
+    - doesn't show ugly `^L` characters with default pager ([objectified](https://github.com/objectified))
 - v0.9 :
     - bugfix
 - v0.8 :
     - `-k` is now case insensitive
-    - Now compatible with python2
+    - Now compatible with python2 ([joshfriend](https://github.com/joshfriend))
 
 - v0.7 :
     - Fixes `-k` ordering by RFC number
+
+## Running tests :
+Simply use `python2 -m unittest discover -v` or `python3 -m unittest discover -v`

--- a/rfc/rfc.py
+++ b/rfc/rfc.py
@@ -150,7 +150,7 @@ class RFCDownloader(object):
                     file_size = int(header[1])
                     break
 
-        elif hasattr(meta, "getheaders"):
+        elif hasattr(meta, "getheaders") and meta.getheaders('Content-Length'):
             file_size = int(meta.getheaders("Content-Length")[0])
 
         else:

--- a/rfc/rfc.py
+++ b/rfc/rfc.py
@@ -14,7 +14,7 @@ try:
 except ImportError:
     from urllib2 import urlopen
 
-__version__ = "0.9"
+__version__ = "1.0"
 
 
 class Config(object):

--- a/rfc/rfc.py
+++ b/rfc/rfc.py
@@ -140,11 +140,19 @@ class RFCDownloader(object):
         f.close()
 
     def _uncompress_bulk_file(self):
+        print("Extracting archive")
         file_name = self.RFC_BULK.split('/')[-1]
         archive_path = os.path.join(self._get_storage_path(), file_name)
         with tarfile.open(archive_path) as tar_file:
-            tar_file.extractall(self._get_storage_path())
+            for tar_file_member in tar_file.getmembers():
+                if tar_file_member.name.endswith('.txt'):
+                    self._uncompress_file_member(tar_file, tar_file_member)
         os.remove(archive_path)
+
+    def _uncompress_file_member(self, tar_file, tar_file_member):
+        contents = tar_file.extractfile(tar_file_member)
+        with open(os.path.join(self._get_storage_path(), os.path.basename(tar_file_member.name)), 'wb') as handle:
+            handle.write(contents.read())
 
 
 class RFCNotFoundException(Exception):

--- a/rfc/rfc.py
+++ b/rfc/rfc.py
@@ -18,7 +18,7 @@ __version__ = "0.9"
 
 
 class Config(object):
-    LOCAL_STORAGE_PATH = "~/.rfc"
+    LOCAL_STORAGE_PATH = os.path.expanduser("~/.rfc")
     INDEX_NAME = "rfc-index.txt"
 
 
@@ -26,7 +26,7 @@ class RFCIndexReader(object):
     START_LINE_REGEX = re.compile("^[0-9]+")
 
     def __init__(self):
-        self._path = os.path.join(os.path.expanduser(Config.LOCAL_STORAGE_PATH), Config.INDEX_NAME)
+        self._path = os.path.join(Config.LOCAL_STORAGE_PATH, Config.INDEX_NAME)
         self.kb = set()
         self._parse_index()
 
@@ -81,7 +81,7 @@ class RFCDownloader(object):
     RFC_INDEX = "https://www.ietf.org/download/rfc-index.txt"
 
     def update(self):
-        full_path = self._get_storage_path()
+        full_path = Config.LOCAL_STORAGE_PATH
         shutil.rmtree(full_path)
         os.mkdir(full_path)
         self._update_bulk(full_path)
@@ -103,12 +103,7 @@ class RFCDownloader(object):
             return False
 
     def is_data_present(self):
-        path = self._get_storage_path()
-        return os.path.exists(path) and len(os.listdir(path)) > 0
-
-    @staticmethod
-    def _get_storage_path():
-        return os.path.expanduser(Config.LOCAL_STORAGE_PATH)
+        return os.path.exists(Config.LOCAL_STORAGE_PATH) and len(os.listdir(Config.LOCAL_STORAGE_PATH)) > 0
 
     @staticmethod
     def _download_file(url, dest):
@@ -160,9 +155,9 @@ class RFCDownloader(object):
 
     def _uncompress_bulk_file(self):
         file_name = self.RFC_BULK.split('/')[-1]
-        archive_path = os.path.join(self._get_storage_path(), file_name)
+        archive_path = os.path.join(Config.LOCAL_STORAGE_PATH, file_name)
         with tarfile.open(archive_path) as tar_file:
-            tar_file.extractall(self._get_storage_path())
+            tar_file.extractall(Config.LOCAL_STORAGE_PATH)
         os.remove(archive_path)
 
 

--- a/rfc/rfc.py
+++ b/rfc/rfc.py
@@ -176,7 +176,7 @@ class RFCDownloader(object):
 
     def _uncompress_file_member(self, tar_file, tar_file_member):
         contents = tar_file.extractfile(tar_file_member)
-        with open(os.path.join(self._get_storage_path(), os.path.basename(tar_file_member.name)), 'wb') as handle:
+        with open(os.path.join(Config.LOCAL_STORAGE_PATH, os.path.basename(tar_file_member.name)), 'wb') as handle:
             handle.write(contents.read())
 
 

--- a/rfc/rfc.py
+++ b/rfc/rfc.py
@@ -262,6 +262,7 @@ class RFCApp(object):
 def exit_wrapper(ret_code=0):
     exit(ret_code)
 
+
 def main(arguments=None):
     parser = argparse.ArgumentParser(
         description="%(prog)s is the python RFC reader. "

--- a/rfc/rfc.py
+++ b/rfc/rfc.py
@@ -18,7 +18,7 @@ __version__ = "0.9"
 
 
 class Config(object):
-    LOCAL_STORAGE_PATH = os.path.expanduser("~/.rfc")
+    LOCAL_STORAGE_PATH = os.path.expanduser(os.getenv('XDG_DATA_HOME', "~/.local/share/rfc"))
     INDEX_NAME = "rfc-index.txt"
 
 

--- a/rfc/rfc.py
+++ b/rfc/rfc.py
@@ -180,8 +180,6 @@ class RFCReader(object):
 
     def __init__(self, pager=None, scan_path=Config.LOCAL_STORAGE_PATH):
         self._path = os.path.expanduser(scan_path)
-        if not os.path.exists(self._path):
-            os.mkdir(self._path)
         self._known_documents_ids = set()
         self._scan()
         self._pager = self._get_pager(pager)
@@ -198,6 +196,8 @@ class RFCReader(object):
         os.system("{} {}".format(self._pager, self._get_file_path(rfc_number)))
 
     def _scan(self):
+        if not os.path.exists(self._path):
+            return
         for file_name in os.listdir(self._path):
             if self.FILE_REGEX.match(file_name):
                 for num in self.NUM_REGEX.findall(file_name):

--- a/rfc/rfc.py
+++ b/rfc/rfc.py
@@ -215,7 +215,7 @@ class RFCReader(object):
         if system_pager is not None:
             return system_pager
 
-        return "less -s"  # Default pager
+        return "less -r -s"  # Default pager
 
 
 class RFCApp(object):

--- a/rfc/rfc.py
+++ b/rfc/rfc.py
@@ -82,7 +82,8 @@ class RFCDownloader(object):
 
     def update(self):
         full_path = Config.LOCAL_STORAGE_PATH
-        shutil.rmtree(full_path)
+        if os.path.exists(full_path):
+            shutil.rmtree(full_path)
         os.mkdir(full_path)
         self._update_bulk(full_path)
         self._update_index(full_path)
@@ -102,7 +103,8 @@ class RFCDownloader(object):
         except Exception:
             return False
 
-    def is_data_present(self):
+    @staticmethod
+    def is_data_present():
         return os.path.exists(Config.LOCAL_STORAGE_PATH) and len(os.listdir(Config.LOCAL_STORAGE_PATH)) > 0
 
     @staticmethod
@@ -174,7 +176,7 @@ class RFCReader(object):
     NUM_REGEX = re.compile('\d+')
 
     def __init__(self, pager=None, scan_path=Config.LOCAL_STORAGE_PATH):
-        self._path = os.path.expanduser(scan_path)
+        self._path = scan_path
         self._known_documents_ids = set()
         self._scan()
         self._pager = self._get_pager(pager)
@@ -220,7 +222,7 @@ class RFCApp(object):
         except NoRFCFound:
             print("No RFC documents found, downloading full archive from IETF site...", file=sys.stderr)
             self._update_docs()
-            self.reader = RFCReader(pager=pager)
+            self.reader = RFCReader(pager)
 
     def open_rfc(self, rfc_number):
         try:
@@ -246,7 +248,7 @@ class RFCApp(object):
         downloader.update()
 
 
-def main():
+def main(arguments=None):
     parser = argparse.ArgumentParser(
         description="%(prog)s is the python RFC reader. "
                     "It stores a local copy of all the RFC "
@@ -269,7 +271,7 @@ def main():
     parser.add_argument('--version', action='version',
                         version='%(prog)s {version}'.format(version=__version__))
 
-    config = parser.parse_args()
+    config = parser.parse_args(args=arguments)
 
     pager = config.pager[0] if config.pager else None
 

--- a/rfc/rfc.py
+++ b/rfc/rfc.py
@@ -165,11 +165,19 @@ class RFCDownloader(object):
         return file_size
 
     def _uncompress_bulk_file(self):
+        print("Extracting archive")
         file_name = self.RFC_BULK.split('/')[-1]
         archive_path = os.path.join(Config.LOCAL_STORAGE_PATH, file_name)
         with tarfile.open(archive_path) as tar_file:
-            tar_file.extractall(Config.LOCAL_STORAGE_PATH)
+            for tar_file_member in tar_file.getmembers():
+                if tar_file_member.name.endswith('.txt'):
+                    self._uncompress_file_member(tar_file, tar_file_member)
         os.remove(archive_path)
+
+    def _uncompress_file_member(self, tar_file, tar_file_member):
+        contents = tar_file.extractfile(tar_file_member)
+        with open(os.path.join(self._get_storage_path(), os.path.basename(tar_file_member.name)), 'wb') as handle:
+            handle.write(contents.read())
 
 
 class RFCNotFoundException(Exception):

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,61 +1,110 @@
 import os
 import shutil
+import sys
 import unittest
 
-from rfc.rfc import RFCDownloader, Config, RFCReader
+import rfc
+from rfc.rfc import Config, RFCDownloader, main, NoRFCFound
 
 
 def touch(fname, times=None):
-    """
-    Utility function
-    """
     with open(fname, 'a'):
         os.utime(fname, times)
 
 
-class TestDownloader(unittest.TestCase):
+P_BUFFER_FILE = "/tmp/out.txt"
+
+
+class TestApp(unittest.TestCase):
     def setUp(self):
-        super().setUp()
-        self.downloader = RFCDownloader()
-        self.remove_data()
-        Config.LOCAL_STORAGE_PATH = "/tmp/rfc_python_download_test/"
-        RFCDownloader.RFC_BULK = "https://www.rfc-editor.org/in-notes/tar/RFCs0001-0500.tar.gz"  # So we don't actually download the whole BULK file
+        Config.LOCAL_STORAGE_PATH = "/tmp/rfc_python_test/"
+        if os.path.exists(Config.LOCAL_STORAGE_PATH):
+            shutil.rmtree(Config.LOCAL_STORAGE_PATH)
+
+        self.print_buffer = None
+        self._exit_value = None
+
+        self._reset_print_buffer()
+        rfc.rfc.exit_wrapper = self._exit_wrapper_override
+
+    def test_rfc_not_found(self):
+        self._create_fake_storage_folder()
+        main(["42"])
+        buffer = self._reset_print_buffer()
+        self.assertTrue("RFC number 42 not found, check your input or re-run with the --update flag" in buffer)
+        self.assertEqual(self._exit_value, 0)
+
+    def test_keyword(self):
+        self._create_fake_storage_folder()
+        self._create_fake_index(Config.LOCAL_STORAGE_PATH)
+        main(["-k", "RFC"])
+        buffer = self._reset_print_buffer()
+        self.assertTrue("RFC" in buffer)
+        self.assertEqual(self._exit_value, 0)
+
+        main(["-k", "there is no rfc with that string in the index"])
+        buffer = self._reset_print_buffer()
+        self.assertEqual(len(buffer), 0)
+        self.assertEqual(self._exit_value, 0)
+
+    def test_no_rfc(self):
+        self.assertFalse(os.path.exists(Config.LOCAL_STORAGE_PATH))
+        RFCDownloader.is_connected, self._is_connected_override = self._is_connected_override, RFCDownloader.is_connected
+        RFCDownloader.RFC_BULK = "What ?"
+        try:
+            main(["42"])
+        except Exception:
+            pass
+        buffer = self._reset_print_buffer()
+        self.assertTrue("No RFC documents found !" in buffer)
+        self.assertTrue("Downloading" in buffer)
+        RFCDownloader.is_connected, self._is_connected_override = self._is_connected_override, RFCDownloader.is_connected
+
+    def test_no_rfc_no_internet(self):
+        self.assertFalse(os.path.exists(Config.LOCAL_STORAGE_PATH))
+        RFCDownloader.RFC_HOME = "http://not_a_valid_url.wtf/"
+        try:
+            main(["42"])
+        except NoRFCFound:
+            pass
+        buffer = self._reset_print_buffer()
+        self.assertTrue("No RFC documents found !" in buffer)
+        self.assertTrue("No internet connection" in buffer)
+        self.assertEqual(self._exit_value, -1)
+
+    def _get_print_buffer_content(self):
+        if os.path.exists(P_BUFFER_FILE):
+            with open(P_BUFFER_FILE, "r") as f:
+                return f.read()
+
+    def _reset_print_buffer(self):
+        """
+        Used to catch print statements to a buffer so we can check them
+        """
+        if self.print_buffer:
+            self.print_buffer.close()
+
+        content = self._get_print_buffer_content()
+        self.print_buffer = open(P_BUFFER_FILE, "w+")
+        sys.stdout = self.print_buffer
+        sys.stderr = self.print_buffer
+        return content
+
+    def _is_connected_override(self):
+        return True
+
+    def _exit_wrapper_override(self, ret_code=0):
+        self._exit_value = ret_code
 
     @staticmethod
-    def remove_data():
-        full_path = os.path.expanduser(Config.LOCAL_STORAGE_PATH)
-        if os.path.exists(full_path):
-            shutil.rmtree(full_path)
+    def _create_fake_storage_folder():
+        os.mkdir(Config.LOCAL_STORAGE_PATH)
+        touch(os.path.join(Config.LOCAL_STORAGE_PATH, "rfc666.txt"))
 
-    def test_internet_connection(self):
-        self.assertTrue(self.downloader.is_connected(), "No internet connection, cannot continue tests")
-
-        # def test_data_available(self):
-        #     self.assertFalse(self.downloader.is_data_present(), "Data shouldn't be present on the system at this point")
-        #     self.downloader.update_bulk()
-        #     self.assertTrue(self.downloader.is_data_present(), "Data should be present")
-
-
-class TestSearch(unittest.TestCase):
-    def setUp(self):
-        super().setUp()
-        Config.LOCAL_STORAGE_PATH = "/tmp/rfc_python_read_test/"
-        local_path = Config.LOCAL_STORAGE_PATH
-        if not os.path.exists(local_path):
-            os.mkdir(local_path)
-        for rfc_num in [40, 41, 42]:
-            touch(os.path.join(local_path, "rfc%d.txt" % rfc_num))
-
-        touch(os.path.join(local_path, "not_rfc_valid_name%d.docx" % 12))
-
-        self.searcher = RFCReader(local_path)
-
-    def test_find_available_rfc(self):
-        self.assertTrue(self.searcher.is_available(40))
-        self.assertTrue(self.searcher.is_available(41))
-        self.assertTrue(self.searcher.is_available(42))
-        self.assertFalse(self.searcher.is_available(39))
-        self.assertFalse(self.searcher.is_available(12))
+    def _create_fake_index(self, path):
+        with open(os.path.join(path, Config.INDEX_NAME), "w") as index:
+            index.write("42\tRFC about the answer to life, universe and everything\n")
+            index.write("666\tDoomsdat RFC, do not read\n")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This code replaces the extractall call with custom extraction code. The .tar.gz from rfc-editor.org seems to contain unneeded .pdf files and for some reason has the executable bit set for some files. The new code only extracts the .txt files to the rfc directory and also shields your homedir from a broken/malicious tar file (since .tar filenames can contain ../ in the path)

Also see the warning in the python docs for extractall: https://docs.python.org/3/library/tarfile.html#tarfile.TarFile.extractall
