### PR TITLE
Issue #8: explicitly check for Content Length header

### DIFF
--- a/rfc/rfc.py
+++ b/rfc/rfc.py
@@ -150,7 +150,7 @@ class RFCDownloader(object):
                     file_size = int(header[1])
                     break
 
-        elif hasattr(meta, "getheaders"):
+        elif hasattr(meta, "getheaders") and meta.getheaders('Content-Length'):
             file_size = int(meta.getheaders("Content-Length")[0])
 
         else:


### PR DESCRIPTION
Fixes issue #8 where a list index out of range error occurs while downloading the index file (the HTTP response from Cloudflare doesn't seem to set a Content-Length header)
