### PR TITLE
instruct less to show raw control chars instead of "^L" etc.

### DIFF
--- a/rfc/rfc.py
+++ b/rfc/rfc.py
@@ -215,7 +215,7 @@ class RFCReader(object):
         if system_pager is not None:
             return system_pager
 
-        return "less -s"  # Default pager
+        return "less -r -s"  # Default pager
 
 
 class RFCApp(object):


### PR DESCRIPTION
By default, ASCII control characters such as form feeds etc. are shown using caret notation (e.g. `^L`). Passing the `-r` parameter to less by default will not have that effect, and tends to look nicer in the case of this tool.
