### PR TITLE
Fix a bug in directory creation

### DIFF
--- a/rfc/rfc.py
+++ b/rfc/rfc.py
@@ -92,7 +92,7 @@ class RFCDownloader(object):
         full_path = Config.LOCAL_STORAGE_PATH
         if os.path.exists(full_path):
             shutil.rmtree(full_path)
-        os.mkdir(full_path)
+        os.makedirs(full_path)
         self._update_bulk(full_path)
         self._update_index(full_path)
 


### PR DESCRIPTION
If the directory ~/.local/share does not exist, os.mkdir() throws an
exception when creating the local storage directory. This issue is fixed
by using os.makedirs(), which creates missing parent directories
automatically.